### PR TITLE
Fix resume.html space between interests commas

### DIFF
--- a/resume.html
+++ b/resume.html
@@ -42,10 +42,18 @@ layout: home
       </div>
       <div class="col-lg-9">
         <p class="m-0">
+          <!-- See https://shopify.github.io/liquid/basics/whitespace/ for whitespace stripping. -->
           {% for entry in site.data.bio.interests %}
-          {{ entry.name }}
-          <!-- Unfortunately the following must all be on a single line so that there are no spaces before the commas. -->
-          {% if entry.keywords and entry.keywords.size > 0 %}({% for keyword in entry.keywords %}{{ keyword }}{% if forloop.last != true %},{% endif %}{% endfor %}){% endif %}{% if forloop.last != true %}, {% endif %}
+          {{ entry.name -}}
+            {% if entry.keywords and entry.keywords.size > 0 %} (
+            {%- for keyword in entry.keywords -%}
+              {{ keyword }}
+              {%- if forloop.last != true -%},
+              {% endif %}
+              {%- endfor -%}
+            ) {%- endif %}
+            {%- if forloop.last != true -%},
+            {% endif %}
           {% endfor %}
         </p>
       </div>


### PR DESCRIPTION
While getting the professional portfolio set up for ICS 314, I noticed spacing issues in the "Interests" section of the "Resume" page.

By adding hyphens at the start and end of the Liquid tags and refactoring the one-liner into several lines, spacing issues were fixed while improving readability (at least in my humble opinion).

Before:
<img width="689" alt="image" src="https://github.com/user-attachments/assets/1f254aa9-352e-4ac2-8a32-ca8e3c31e6b1">

After:
<img width="685" alt="image" src="https://github.com/user-attachments/assets/fdf1f8dc-912b-4272-a4ea-97c5f56fc1bb">

These were generated from the following set of interests in `bio.json`:
```json
    "interests": [
        {
            "name": "DevOps"
        },
        {
            "name": "Terminal-based workflows"
        },
        {
            "name": "Linux",
            "keywords": ["Keyword1", "Keyword2"]
        },
        {
            "name": "Digital signal processing",
        }
    ]
```

More information on whitespace control can be found [here](https://shopify.github.io/liquid/basics/whitespace/).

---

As an aside, I am not familiar with the processes/etiquette behind contributing via pull requests, and wasn't sure if there was a particular set of guidelines to contributing to Techfolios. Please let me know if I can improve anywhere in that regard.